### PR TITLE
As/output validation

### DIFF
--- a/aws_cloudfront_distribution.tf
+++ b/aws_cloudfront_distribution.tf
@@ -5,7 +5,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     origin_id   = "${data.aws_s3_bucket.origin_bucket.id}-origin"
 
     s3_origin_config {
-      origin_access_identity = aws_cloudfront_origin_access_identity.current.cloudfront_access_identity_path
+      origin_access_identity = local.shared_origin_path
     }
   }
   comment         = "${var.distribution_name} distribution"
@@ -93,7 +93,9 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
   depends_on = [module.bucket_cloudwatch_logs_backup, aws_acm_certificate.certificate]
 }
 
-resource "aws_cloudfront_origin_access_identity" "current" {}
+resource "aws_cloudfront_origin_access_identity" "current" {
+        count = var.shared_origin_access_identity != "" ? 0 : 1
+}
 
 resource "aws_cloudfront_response_headers_policy" "security_headers_policy" {
   name  = "${var.distribution_name}-cloudfront-security-headers-policy"

--- a/aws_s3_origin_bucket_policy.tf
+++ b/aws_s3_origin_bucket_policy.tf
@@ -1,9 +1,11 @@
 resource "aws_s3_bucket_policy" "allow_cloudfront" {
+  count = var.shared_origin_access_identity != "" ? 0 : 1
   bucket = data.aws_s3_bucket.origin_bucket.id
-  policy = data.aws_iam_policy_document.cloudfront.json
+  policy = data.aws_iam_policy_document.cloudfront[0].json
 }
 
 data "aws_iam_policy_document" "cloudfront" {
+  count = var.shared_origin_access_identity != "" ? 0 : 1
   statement {
     actions = [
       "s3:ListBucket",
@@ -14,7 +16,7 @@ data "aws_iam_policy_document" "cloudfront" {
     principals {
       type = "AWS"
       identifiers = [
-        aws_cloudfront_origin_access_identity.current.iam_arn,
+        aws_cloudfront_origin_access_identity.current[0].iam_arn,
       ]
     }
   }
@@ -30,7 +32,7 @@ data "aws_iam_policy_document" "cloudfront" {
       type = "AWS"
 
       identifiers = [
-        aws_cloudfront_origin_access_identity.current.iam_arn,
+        aws_cloudfront_origin_access_identity.current[0].iam_arn,
       ]
     }
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,3 +10,6 @@ output "identity" {
   value = aws_cloudfront_origin_access_identity.current
 }
 
+output "domain_validations" {
+  value = aws_route53_record.certificate_validation
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,7 +7,7 @@ output "distribution" {
 }
 
 output "identity" {
-  value = aws_cloudfront_origin_access_identity.current
+  value = try(aws_cloudfront_origin_access_identity.current[0], "")
 }
 
 output "domain_validations" {

--- a/variables.tf
+++ b/variables.tf
@@ -109,6 +109,12 @@ variable "response_header_policy_enable" {
   default     = true
 }
 
+variable "shared_origin_access_identity" {
+  description = "cloudfront_access_identity_path from a previous distribution, so we can use the same origin"
+  type        = string
+  default     = ""
+}
+
 variable "use_cloudfront_default_certificate" {
   type        = bool
   description = "Default SSL certificate."
@@ -134,4 +140,5 @@ variable "common_tags" {
 
 locals {
   logging_bucket_name = "${var.distribution_name}-cf-logs-${data.aws_region.current.name}-${lower(data.aws_iam_account_alias.current.account_alias)}"
+  shared_origin_path  = var.shared_origin_access_identity != "" ? var.shared_origin_access_identity : aws_cloudfront_origin_access_identity.current[0].cloudfront_access_identity_path
 }


### PR DESCRIPTION
Further enablements for white-labelling.

We share an S3 bucket as the origin, so we want to have the option of sharing the Cloudfront origin from the original distribution.

This commit allows us to provide a parameter in this form:
`shared_origin_access_identity     = module.cloudfront_profile.identity.cloudfront_access_identity_path`
This re-uses a pre-existing cloudfront identity