### PR TITLE
Allow whitelist distributions to be stood up before certs are finalized

### DIFF
--- a/aws_acm_certificates.tf
+++ b/aws_acm_certificates.tf
@@ -10,6 +10,7 @@ resource "aws_acm_certificate" "certificate" {
 }
 
 resource "aws_acm_certificate_validation" "cert" {
+  count                   = var.whitelabel_domain ? 0 : 1
   provider                = aws.cloudfront
   certificate_arn         = aws_acm_certificate.certificate.arn
   validation_record_fqdns = [for record in aws_route53_record.certificate_validation : record.fqdn]

--- a/aws_cloudfront_distribution.tf
+++ b/aws_cloudfront_distribution.tf
@@ -16,7 +16,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 
   viewer_certificate {
     cloudfront_default_certificate = var.use_cloudfront_default_certificate
-    acm_certificate_arn            = aws_acm_certificate.certificate.arn
+    acm_certificate_arn            = var.use_cloudfront_default_certificate ? "" : aws_acm_certificate.certificate.arn
     ssl_support_method             = "sni-only"
     minimum_protocol_version       = var.minimum_protocol_version
   }
@@ -28,9 +28,7 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     response_page_path    = "/index.html"
   }
 
-  aliases = [
-    var.distribution_fqdn
-  ]
+  aliases = var.use_cloudfront_default_certificate ? [] : [var.distribution_fqdn]
 
   logging_config {
     bucket          = module.bucket_cloudwatch_logs_backup.s3_bucket_bucket_domain_name

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,5 +11,5 @@ output "identity" {
 }
 
 output "domain_validations" {
-  value = aws_route53_record.certificate_validation
+  value = aws_acm_certificate.certificate.domain_validation_options
 }


### PR DESCRIPTION
This avoids the catch-22 of a distribution requiring a valid cname that points to it before it can be created

Imply two terraform runs when creating whitelisted domains:
1: use_cloudfront_default_certificate = true  # In order to create a "blank" distribution
2: use_cloudfront_default_certificate = false  # To use the actual certificate